### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
     - "2.7"
+    - "3.5"
 env:
     - GMPY2=
     - GMPY2=gmpy2 LD_LIBRARY_PATH=/usr/local/lib

--- a/pwnbox/__init__.py
+++ b/pwnbox/__init__.py
@@ -1,6 +1,6 @@
 """Python toolbox for hacking and problem solving
 """
 
-import pipe
-import number
-import utils
+from . import pipe
+from . import number
+from . import utils

--- a/pwnbox/number.py
+++ b/pwnbox/number.py
@@ -1,7 +1,12 @@
 """Number theory algorithms.
 """
 
-from functools import wraps
+from functools import reduce, wraps
+
+try:
+    xrange
+except NameError:
+    xrange = range
 
 has_gmpy2 = False
 try:
@@ -27,25 +32,26 @@ def crt(remainders, moduli, coprime = True):
     :param coprime: (optional) set ``False`` if modulies are not coprimes.
     """
     if not coprime:
-        v, m = remainders[0], moduli[0]
-        for u, n in zip(remainders, moduli)[1:]:
+        iternums = iter(zip(remainders, moduli))
+        v, m = next(iternums)
+        for u, n in iternums:
             g, s, t = gmpy2.gcdext(m, n)
             assert(v % g == u%g)
-            v += s * m / g * (u - v)
-            m *= n / g
+            v += s * m // g * (u - v)
+            m *= n // g
         return (v % m, m)
 
     p = reduce(lambda x, y : x * y, moduli)
     v = 0
     for u, m in zip(remainders, moduli):
-        e = p / m
+        e = p // m
         g, s, t = gmpy2.gcdext(e, m)
         v += e * (u * s % m)
     return (v % p, p)
 
 @gmpy2_required
 def cf(n, m):
-    """Rational number ``n / m`` to continued fraction.
+    """Rational number ``n // m`` to continued fraction.
 
     :param n: numerator.
     :param m: denominator.
@@ -85,7 +91,7 @@ def wiener_attack(N, e):
     for k,d in convergents:
         if k == 0 or (e * d - 1) % k != 0:
             continue
-        phi = (e * d - 1) / k
+        phi = (e * d - 1) // k
         c = N - phi + 1
         # now p,q can be the root of x**2 - s*x + n = 0
         det = c * c - 4 * N
@@ -93,7 +99,7 @@ def wiener_attack(N, e):
             continue
         s, r = gmpy2.isqrt_rem(det)
         if r == 0 and gmpy2.is_even(c + s):
-            return (d, (c + s) / 2,(c - s) / 2)
+            return (d, (c + s) // 2,(c - s) // 2)
     # Failed
     return None
 

--- a/pwnbox/pipe/__init__.py
+++ b/pwnbox/pipe/__init__.py
@@ -20,7 +20,7 @@
 
 """
 
-from basepipe import BasePipe
-from socketpipe import SocketPipe, connect
-from processpipe import ProcessPipe, popen
-from pipe import Pipe, pipe
+from .basepipe import BasePipe
+from .socketpipe import SocketPipe, connect
+from .processpipe import ProcessPipe, popen
+from .pipe import Pipe, pipe

--- a/pwnbox/pipe/pipe.py
+++ b/pwnbox/pipe/pipe.py
@@ -1,6 +1,6 @@
 import os
 
-from basepipe import BasePipe
+from .basepipe import BasePipe
 
 class Pipe(BasePipe):
     """An echo pipe with ``os.pipe()``.

--- a/pwnbox/pipe/processpipe.py
+++ b/pwnbox/pipe/processpipe.py
@@ -1,7 +1,7 @@
 import subprocess
 import shlex
 
-from basepipe import BasePipe
+from .basepipe import BasePipe
 
 class ProcessPipe(BasePipe):
     """A pipe with local process.

--- a/pwnbox/pipe/socketpipe.py
+++ b/pwnbox/pipe/socketpipe.py
@@ -1,6 +1,6 @@
 import socket
 
-from basepipe import BasePipe
+from .basepipe import BasePipe
 
 class SocketPipe(BasePipe):
     """A pipe with a TCP connection.

--- a/pwnbox/utils.py
+++ b/pwnbox/utils.py
@@ -2,40 +2,46 @@
 """
 
 import operator
+import codecs
+
+try:
+    xrange
+except NameError:
+    xrange = range
 
 def dtol(num):
     """Integer to DWORD in little endian.
     """
-    return ("%08x" % (num & 0xFFFFFFFF)).decode("hex")[::-1]
+    return codecs.decode("%08x" % (num & 0xFFFFFFFF), "hex")[::-1]
 
 def dtob(num):
     """Integer to DWORD in big endian.
     """
-    return ("%08x" % (num & 0xFFFFFFFF)).decode("hex")
+    return codecs.decode("%08x" % (num & 0xFFFFFFFF), "hex")
 
 def qtol(num):
     """Integer to QWORD in little endian.
     """
-    return ("%016x" % (num & 0xFFFFFFFFFFFFFFFF)).decode("hex")[::-1]
+    return codecs.decode("%016x" % (num & 0xFFFFFFFFFFFFFFFF), "hex")[::-1]
 
 def qtob(num):
     """Integer to QWORD in big endian.
     """
-    return ("%016x" % (num & 0xFFFFFFFFFFFFFFFF)).decode("hex")
+    return codecs.decode("%016x" % (num & 0xFFFFFFFFFFFFFFFF), "hex")
 
 def ltoi(mem):
     """Little endian bytes to integer.
     """
-    return int(mem[::-1].encode("hex"), 16)
+    return int(codecs.encode(mem[::-1].encode("latin1"), "hex"), 16)
 
 def btoi(mem):
     """Big endian bytes to integer.
     """
-    return int(mem.encode("hex"), 16)
+    return int(codecs.encode(mem.encode("latin1"), "hex"), 16)
 
 def sopr(a, b, f):
     t = max(len(a), len(b))
-    return "".join([chr(f(ord(a.ljust(t, "\x00")[i]), ord(b.ljust(t, "\x00")[i]))) for i in xrange(t)])
+    return bytes(bytearray([f(ord(a.ljust(t, b"\x00")[i:i + 1]), ord(b.ljust(t, b"\x00")[i:i + 1])) for i in xrange(t)]))
 
 def sand(a, b):
     """Bitwise and operator on string.
@@ -55,4 +61,4 @@ def sxor(a, b):
 def sinv(a):
     """Bitwise inverse operator on string.
     """
-    return "".join([chr(ord(i) ^ 0xff) for i in a])
+    return bytes(bytearray([ord(a[i:i + 1]) ^ 0xff for i in xrange(len(a))]))

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,5 +1,6 @@
 import unittest
 import random
+from functools import reduce
 from Crypto.Util.number import getPrime
 from pwnbox import number
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,16 +3,16 @@ from pwnbox import utils
 
 class TestTos(unittest.TestCase):
     def test_dtol(self):
-        self.assertEqual(utils.dtol(0x01234567), "\x67\x45\x23\x01")
+        self.assertEqual(utils.dtol(0x01234567), b"\x67\x45\x23\x01")
 
     def test_dtob(self):
-        self.assertEqual(utils.dtob(0x01234567), "\x01\x23\x45\x67")
+        self.assertEqual(utils.dtob(0x01234567), b"\x01\x23\x45\x67")
 
     def test_qtol(self):
-        self.assertEqual(utils.qtol(0x0123456789abcdef), "\xef\xcd\xab\x89\x67\x45\x23\x01")
+        self.assertEqual(utils.qtol(0x0123456789abcdef), b"\xef\xcd\xab\x89\x67\x45\x23\x01")
 
     def test_qtob(self):
-        self.assertEqual(utils.qtob(0x0123456789abcdef), "\x01\x23\x45\x67\x89\xab\xcd\xef")
+        self.assertEqual(utils.qtob(0x0123456789abcdef), b"\x01\x23\x45\x67\x89\xab\xcd\xef")
 
     def test_ltoi(self):
         self.assertEqual(utils.ltoi("\x67\x45\x23\x01"), 0x01234567)


### PR DESCRIPTION
We need to import modules or submodules by using absolute paths either relative paths.

- [x] `OverflowError: integer division result too large for a float` on `e = p / m`, `number.py`

    ``` diff
    -e = p / m
    +e = p // m
    ```
- [x] `TypeError: 'zip' object is not subscriptable` on `number.py`

    ``` diff
    -v, m = remainders[0], moduli[0]
    -for u, n in zip(remainders, moduli)[1:]:
    +iternums = iter(zip(remainders, moduli))
    +v, m = next(iternums)
    +for u, n in iternums:
       # ...
    ```
- [x] `NameError: name 'reduce' is not defined`

    ``` python
    from functools import reduce
    ```
- [x] `NameError: name 'xrange' is not defined`

    ``` python
    try:
        xrange
    except NameError:
        xrange = range
    ```
- [x] `TypeError: a bytes-like object is required, not 'str'` on `os.write()`, `basepipe.py`

    ``` diff
    -os.read(fd, 4096)
    +os.read(fd, 4096).decode('latin1')
    ```
    ``` diff
    -os.write(fd, data)
    +os.write(fd, data.encode('latin1'))
    ```
- [x] `AttributeError: 'str' object has no attribute 'decode'` on `utils.py`

    ``` python
    import codecs
    codecs.decode("%08x" % (num & 0xFFFFFFFF), "hex")
    int(codecs.encode(mem.encode("latin1"), "hex"), 16)
    ```
- [x] `LookupError: 'hex' is not a text encoding; use codec.encode() to handle arbitrary codecs` on `utils.py`

    ``` python
    import codecs
    codecs.decode("%08x" % (num & 0xFFFFFFFF), "hex")
    int(codecs.encode(mem.encode("latin1"), "hex"), 16)
    ```
- [x] `AssertionError: '\xff\xfe\xbd\xde' != u'\xff\xfe\xbd\xde'` on `test_sor`, `test_utils.py`

    ``` diff
    -return "".join([chr(f(ord(a.ljust(t, "\x00")[i]), ord(b.ljust(t, "\x00")[i]))) for i in xrange(t)])
    +return bytes(bytearray([f(ord(a.ljust(t, b"\x00")[i:i + 1]), ord(b.ljust(t, b"\x00")[i:i + 1])) for i in xrange(t)]))
    ```
    ``` diff
    -return "".join([chr(ord(i) ^ 0xff) for i in a])
    +return bytes(bytearray([ord(a[i:i + 1]) ^ 0xff for i in xrange(len(a))]))
    ```
    ``` diff
    -self.assertEqual(utils.dtol(0x01234567), "\x67\x45\x23\x01")
    +self.assertEqual(utils.dtol(0x01234567), b"\x67\x45\x23\x01")
    ```