### PR TITLE
Fix latin1 encoding problem for Python 2

### DIFF
--- a/pwnbox/utils.py
+++ b/pwnbox/utils.py
@@ -3,6 +3,7 @@
 
 import operator
 import codecs
+import six
 
 try:
     xrange
@@ -32,12 +33,12 @@ def qtob(num):
 def ltoi(mem):
     """Little endian bytes to integer.
     """
-    return int(codecs.encode(mem[::-1].encode("latin1"), "hex"), 16)
+    return int(codecs.encode(six.b(mem[::-1]), "hex"), 16)
 
 def btoi(mem):
     """Big endian bytes to integer.
     """
-    return int(codecs.encode(mem.encode("latin1"), "hex"), 16)
+    return int(codecs.encode(six.b(mem), "hex"), 16)
 
 def sopr(a, b, f):
     t = max(len(a), len(b))

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name = "pwnbox",
     version = "0.4",
     packages = find_packages(),
+    install_requires = ['six'],
     test_suite = "nose.collector",
     tests_require = ["nose", "pycrypto"],
     author = "Hyeonseop Lee",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,21 +4,27 @@ from pwnbox import utils
 class TestTos(unittest.TestCase):
     def test_dtol(self):
         self.assertEqual(utils.dtol(0x01234567), b"\x67\x45\x23\x01")
+        self.assertEqual(utils.dtol(0x012345ff), b"\xff\x45\x23\x01")
 
     def test_dtob(self):
         self.assertEqual(utils.dtob(0x01234567), b"\x01\x23\x45\x67")
+        self.assertEqual(utils.dtob(0x012345ff), b"\x01\x23\x45\xff")
 
     def test_qtol(self):
         self.assertEqual(utils.qtol(0x0123456789abcdef), b"\xef\xcd\xab\x89\x67\x45\x23\x01")
+        self.assertEqual(utils.qtol(0x0123456789abcdff), b"\xff\xcd\xab\x89\x67\x45\x23\x01")
 
     def test_qtob(self):
         self.assertEqual(utils.qtob(0x0123456789abcdef), b"\x01\x23\x45\x67\x89\xab\xcd\xef")
+        self.assertEqual(utils.qtob(0x0123456789abcdff), b"\x01\x23\x45\x67\x89\xab\xcd\xff")
 
     def test_ltoi(self):
         self.assertEqual(utils.ltoi("\x67\x45\x23\x01"), 0x01234567)
+        self.assertEqual(utils.ltoi("\xff\x45\x23\x01"), 0x012345ff)
 
     def test_btoi(self):
         self.assertEqual(utils.btoi("\x01\x23\x45\x67"), 0x01234567)
+        self.assertEqual(utils.btoi("\x01\x23\x45\xff"), 0x012345ff)
 
 class TestSoprs(unittest.TestCase):
     def test_sand(self):


### PR DESCRIPTION
We should call `.encode("latin1")` on Python 3, but should not on Python 2. `"\xff\x45\x23\x01".encode("latin1")` raises `UnicodeDecodeError` on Python 2:

``` python
>>> "\xff\x45\x23\x01".encode("latin1")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xff in position 0: ordinal not in range(128)
```

I introduced a dependency to module [`six`](https://pypi.python.org/pypi/six/), but [`six.b(data)`](https://pythonhosted.org/six/#six.b) was used twice only. So if you don't want to add a dependency, we can check the version of python manually.